### PR TITLE
Collective update 2016-03-07

### DIFF
--- a/djangae/Dockerfile
+++ b/djangae/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 
 # Download and install the Appengine Python SDK
 ADD gaesdk_download.py /tmp/gaesdk_download.py
-RUN /tmp/gaesdk_download.py 1.9.31 && \
+RUN /tmp/gaesdk_download.py 1.9.33 && \
     rm -rf /tmp/*
 ENV PATH /opt/google_appengine:$PATH
 

--- a/djangae/Dockerfile
+++ b/djangae/Dockerfile
@@ -6,6 +6,10 @@ RUN apt-get update && \
         apt-transport-https \
         build-essential \
         libxslt1-dev \
+        mysql-client \
+        libmysqlclient-dev \
+        ipython \
+        sqlite3 \
         python-imaging \
         python-numpy \
         python-dev \

--- a/djangae/app.yaml
+++ b/djangae/app.yaml
@@ -4,6 +4,10 @@ runtime: python27
 api_version: 1
 threadsafe: true
 
+libraries:
+- name: lxml
+  version: 2.3.5
+
 handlers:
 
 - url: /_ah/(mapreduce|queue|warmup|internalupload).*

--- a/djangae/app.yaml
+++ b/djangae/app.yaml
@@ -7,6 +7,8 @@ threadsafe: true
 libraries:
 - name: lxml
   version: 2.3.5
+- name: PIL
+  version: 1.1.7
 - name: MySQLdb
   version: 1.2.5
 

--- a/djangae/app.yaml
+++ b/djangae/app.yaml
@@ -7,6 +7,8 @@ threadsafe: true
 libraries:
 - name: lxml
   version: 2.3.5
+- name: MySQLdb
+  version: 1.2.5
 
 handlers:
 

--- a/djangae/requirements.txt
+++ b/djangae/requirements.txt
@@ -7,6 +7,7 @@ django-session-csrf
 nose
 six
 lxml==2.3.5
+MySQL-python==1.2.5
 
 # Uncomment these to use mapreduce or djangae.contrib.uniquetool (which uses mapreduce)
 # These are forks of Google's libraries, which contain various fixes and patches

--- a/djangae/requirements.txt
+++ b/djangae/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/potatolondon/djangae.git#egg=djangae
-django==1.8
+git+https://github.com/potatolondon/djangae.git@a97d8907a254a96e245465716d89d252f1cd13c8#egg=djangae
+django==1.8.11
 django-secure
 django-csp
 git+https://github.com/adamalton/django-csp-reports.git#egg=cspreports

--- a/djangae/requirements.txt
+++ b/djangae/requirements.txt
@@ -6,7 +6,7 @@ git+https://github.com/adamalton/django-csp-reports.git#egg=cspreports
 django-session-csrf
 nose
 six
-lxml==3.4.1
+lxml==2.3.5
 
 # Uncomment these to use mapreduce or djangae.contrib.uniquetool (which uses mapreduce)
 # These are forks of Google's libraries, which contain various fixes and patches


### PR DESCRIPTION
This PR updates a few outstanding changes that aid development and correct issues when running or deploying a Djangae based project.
- Bump GAE SDK version to 1.9.33
- Bump Django version to 1.8.11
- Bump Djangae version to 2016-03-04
- Downgrade lxml version to 2.3.5
- Load PIL by default
- Add in MySQL related packages, and enable version 1.2.5
