### PR TITLE
Remove pytest-sugar and add coverage support

### DIFF
--- a/appengine-dev/ops/assets/requirements.txt
+++ b/appengine-dev/ops/assets/requirements.txt
@@ -14,6 +14,6 @@ lxml==3.4.1
 mock==1.0.1
 nose==1.3.4
 pytest==3.0.6
-pytest-sugar==0.8.0
+pytest-cov==2.4.0
 yanc==0.2.4
 WebTest==2.0.25


### PR DESCRIPTION
pytest-sugar is useless since docker does not handle shell
colors very well. This results in an output full of shell
opcodes rather than nice test report. The built in reporter
is more readable in this case.